### PR TITLE
Add local font options

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const Canvas = require('canvas');
  * @param text
  * @param [option]
  * @param [option.font='30px sans-serif']
+ * @param [option.localFontName='localFont']
+ * @param [option.localFontPath]
  * @param [option.textColor='black']
  * @param [option.bgColor]
  * @param [option.lineSpacing=0]
@@ -17,6 +19,7 @@ const Canvas = require('canvas');
 module.exports = (text, option) => {
   option = option || {};
   option.font = option.font || '30px sans-serif';
+  option.localFontName = option.localFontName || 'localFont';
   option.textColor = option.textColor || 'black';
   option.lineSpacing = option.lineSpacing || 0;
   option.padding = option.padding || 0;
@@ -25,6 +28,11 @@ module.exports = (text, option) => {
   const canvas = new Canvas(0, 0);
   const ctx = canvas.getContext('2d');
 
+  if(option.localFontPath) {
+    ctx.addFont(new Canvas.Font(option.localFontName, option.localFontPath));
+    option.font = (option.font === '30px sans-serif') ? `30px ${option.localFontName}` : option.font;
+  }
+  
   const max = {
     left: 0,
     right: 0,


### PR DESCRIPTION
日本語入りの文章を画像化する必要があり、ローカルのフォントを使用したくなったので機能追加してみました。
やり方は、こちらの記事からお借りしています。

- [Bluemix + Node-Canvas で日本語を表示する](http://dotnsf.blog.jp/archives/1066073209.html)

追加したoptionは`localFontName`と`localFontPath`の2つです。

### とりあえずローカルのフォントを使いたい場合
```js
text2png('日本語の文章', {
  localFontPath : 'font/mylocalfont.ttf'
});
```
### サイズも指定したい場合
```js
text2png('日本語の文章', {
  font :　'20px sugoi_font',
  localFontName : 'sugoi_font',
  localFontPath : 'font/mylocalfont.ttf'
});
```

フォントサイズとフォント名のオプションが別であればわざわざ名称を与える必要はなくなりますが、元のオプションを改変するのもまずそうなのでこのような形にしてみました。

---

書いてからissueを見たのですが、#1 への対応にもなりそうですね……。
これで問題なければREADMEにも追記しますので、コードをご確認頂ければと思います。