### PR TITLE
Update parseOptions to allow local fonts

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,9 @@ function parseOptions(options) {
     paddingBottom       : options.paddingBottom || options.padding || 0,
     textAlign           : options.textAlign || 'left',
     textColor           : options.textColor || options.color || 'black',
-    output              : options.output || 'buffer'
+    output              : options.output || 'buffer',
+    localFontName       : options.localFontName || null,
+    localFontPath       : options.localFontPath || null
   };
 }
 


### PR DESCRIPTION
Since alpha.1 the parseOptions function has been added, which filters out local font options.

https://github.com/tkrkt/text2png/compare/v2.0.0-alpha.1...master?diff=unified&name=master#diff-168726dbe96b3ce427e7fedce31bb0bcR33

Fixes: #10 