### PR TITLE
added changes for deregistering all fonts from memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { registerFont, createCanvas } = require("canvas");
+const { registerFont, createCanvas, deregisterAllFonts } = require("canvas");
 
 /**
  * Convert text to PNG image.
@@ -30,10 +30,11 @@ const { registerFont, createCanvas } = require("canvas");
 const text2png = (text, options = {}) => {
   // Options
   options = parseOptions(options);
-
+  var isFontLoadedInMemory = false
   // Register a custom font
   if (options.localFontPath && options.localFontName) {
     registerFont(options.localFontPath, { family: options.localFontName });
+    isFontLoadedInMemory = true;
   }
 
   const canvas = createCanvas(0, 0);
@@ -158,7 +159,9 @@ const text2png = (text, options = {}) => {
 
     offsetY += lineHeight;
   });
-
+  if(isFontLoadedInMemory){
+    deregisterAllFonts()
+  }
   switch (options.output) {
     case "buffer":
       return canvas.toBuffer();


### PR DESCRIPTION
While using this package in production we were getting memory issues,
with a tps of 100 we were getting somewhere around 15-20% CPU with RAM being overloaded and kept on increasing from 700MB to around 7-8GB and didn't release RAM and server's got stuck post sometime as no memory was free to handle new request.

The main reason for the same was that the library didn't unload the font that which canvas library provided, and it kept on pilling up the fonts file.
